### PR TITLE
Improve file manager robustness

### DIFF
--- a/src/file_manager.c
+++ b/src/file_manager.c
@@ -1,10 +1,18 @@
 #include "file_manager.h"
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
-uint16_t* fileIndexBuffer;
-fileData* fileDataBuffer;
+/*
+ * Fall back to statically allocated storage if the heap cannot satisfy the
+ * allocations requested in file_manager_init().  This keeps the menu usable
+ * even in low-memory scenarios instead of crashing when the global pointers
+ * remain NULL.
+ */
+static uint16_t fileIndexStatic[MAX_FILE_ITEMS];
+static fileData fileDataStatic[MAX_FILE_ITEMS];
+
+uint16_t *fileIndexBuffer;
+fileData *fileDataBuffer;
 
 int file_manager_compare(uint16_t indexA, uint16_t indexB) 
 {
@@ -18,23 +26,38 @@ int file_manager_compare(uint16_t indexA, uint16_t indexB)
     return strcmp(a->filename, b->filename);
 }
 
-void file_manager_quicksort(uint16_t left, uint16_t right) 
+static void file_manager_quicksort(int left, int right)
 {
     if (left >= right)
     {
         return;
     }
 
-    int pivotIndex = fileIndexBuffer[(left + right) / 2];
+    /*
+     * Use signed indices internally so that calls such as sort(0) do not cause
+     * the "right" parameter to wrap around and index past the end of the
+     * buffers.  This also avoids repeated integer promotions in the hot loops.
+     */
+    const int pivotIndex = fileIndexBuffer[left + ((right - left) / 2)];
 
     int i = left;
     int j = right;
 
-    while (i <= j) {
-        while (file_manager_compare(fileIndexBuffer[i], pivotIndex) < 0) i++;
-        while (file_manager_compare(fileIndexBuffer[j], pivotIndex) > 0) j--;
-        if (i <= j) {
-            uint16_t temp = fileIndexBuffer[i];
+    while (i <= j)
+    {
+        while (file_manager_compare(fileIndexBuffer[i], pivotIndex) < 0)
+        {
+            i++;
+        }
+
+        while (file_manager_compare(fileIndexBuffer[j], pivotIndex) > 0)
+        {
+            j--;
+        }
+
+        if (i <= j)
+        {
+            const uint16_t temp = fileIndexBuffer[i];
             fileIndexBuffer[i] = fileIndexBuffer[j];
             fileIndexBuffer[j] = temp;
             i++;
@@ -42,11 +65,18 @@ void file_manager_quicksort(uint16_t left, uint16_t right)
         }
     }
 
-    if (left < j) file_manager_quicksort(left, j);
-    if (i < right) file_manager_quicksort(i, right);
+    if (left < j)
+    {
+        file_manager_quicksort(left, j);
+    }
+
+    if (i < right)
+    {
+        file_manager_quicksort(i, right);
+    }
 }
 
-void file_manager_clean_list(uint16_t* count)
+void file_manager_clean_list(uint16_t *count)
 {
     int i = 0;
     while (i < *count - 1)
@@ -75,33 +105,72 @@ void file_manager_clean_list(uint16_t* count)
     }
 }
 
-void file_manager_init()
+void file_manager_init(void)
 {
-	fileIndexBuffer = (uint16_t*)malloc(sizeof(uint16_t) * MAX_FILE_ITEMS);
-	fileDataBuffer = (fileData*)malloc(sizeof(fileData) * MAX_FILE_ITEMS);
+    uint16_t *const indexAlloc = (uint16_t *)malloc(sizeof(uint16_t) * MAX_FILE_ITEMS);
+    fileData *const dataAlloc = (fileData *)malloc(sizeof(fileData) * MAX_FILE_ITEMS);
+
+    if (!indexAlloc || !dataAlloc)
+    {
+        /*
+         * Low-memory situations are rare but catastrophic if we kept the NULL
+         * pointers: guard against them by falling back to the static buffers.
+         */
+        free(indexAlloc);
+        free(dataAlloc);
+        fileIndexBuffer = fileIndexStatic;
+        fileDataBuffer = fileDataStatic;
+        return;
+    }
+
+    fileIndexBuffer = indexAlloc;
+    fileDataBuffer = dataAlloc;
 }
 
-void file_manager_init_file_data(uint16_t index, uint8_t flag, char* filename, uint16_t filename_length)
+void file_manager_init_file_data(uint16_t index, uint8_t flag, const char *filename, uint16_t filename_length)
 {
-	fileData* file = &fileDataBuffer[index];
-	file->flag = flag;
-	memcpy(file->filename, filename, filename_length);
-	file->filename[filename_length] = 0;
-	fileIndexBuffer[index] = index;
+    fileData *file = &fileDataBuffer[index];
+
+    /*
+     * Clamp and copy the filename manually to make sure we never overrun the
+     * destination buffer, even if the caller passes a bogus length.
+     */
+    file->flag = flag;
+
+    uint16_t safeLength = 0;
+    if (filename != NULL)
+    {
+        safeLength = filename_length;
+        if (safeLength > MAX_FILE_LENGTH)
+        {
+            safeLength = MAX_FILE_LENGTH;
+        }
+
+        memcpy(file->filename, filename, safeLength);
+    }
+
+    file->filename[safeLength] = '\0';
+    fileIndexBuffer[index] = index;
 }
 
-fileData* file_manager_get_file_data(uint16_t index)
+fileData *file_manager_get_file_data(uint16_t index)
 {
-	uint16_t fileIndex = fileIndexBuffer[index];
-	return &fileDataBuffer[fileIndex];
+    const uint16_t fileIndex = fileIndexBuffer[index];
+    return &fileDataBuffer[fileIndex];
 }
 
 uint16_t file_manager_get_file_index(uint16_t index)
 {
-	return fileIndexBuffer[index];
+    return fileIndexBuffer[index];
 }
 
 void file_manager_sort(uint16_t count)
 {
-	file_manager_quicksort(0, count - 1);
+    if (count < 2)
+    {
+        /* Sorting zero or one element is a no-op and avoids signed wraparound. */
+        return;
+    }
+
+    file_manager_quicksort(0, (int)count - 1);
 }

--- a/src/file_manager.h
+++ b/src/file_manager.h
@@ -7,13 +7,14 @@
 
 typedef struct
 {
-	uint8_t flag;
-	char filename[MAX_FILE_LENGTH + 1];
+        uint8_t flag;
+        char filename[MAX_FILE_LENGTH + 1];
 } fileData;
 
-void file_manager_init();
-void file_manager_init_file_data(uint16_t index, uint8_t flag, char* filename, uint16_t filename_length);
-fileData* file_manager_get_file_data(uint16_t index);
+void file_manager_init(void);
+void file_manager_init_file_data(uint16_t index, uint8_t flag, const char *filename, uint16_t filename_length);
+fileData *file_manager_get_file_data(uint16_t index);
 uint16_t file_manager_get_file_index(uint16_t index);
 void file_manager_sort(uint16_t count);
-void file_manager_clean_list(uint16_t* count);
+void file_manager_clean_list(uint16_t *count);
+


### PR DESCRIPTION
## Summary
- add a static fall-back buffer for the file manager to survive allocation failures
- guard the sorting entry point against unsigned wrap-around and use signed indices inside the quicksort implementation
- clamp copied filenames safely and update the header declarations to use const-correct pointers

## Testing
- cmake -S . -B build *(fails: missing PS1 cross-compilation toolchain in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d77df60c832f982fb9f1177a8217